### PR TITLE
Redact values in bodies by default

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,2 +1,2 @@
 run:
-  tests: true
+  tests: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,2 +1,2 @@
 run:
-  tests: false
+  tests: true

--- a/event.go
+++ b/event.go
@@ -214,11 +214,6 @@ func (rc *readCloser) Close() error {
 }
 
 func duplicateBody(r io.ReadCloser) (body any, rc io.ReadCloser) {
-	// Network error failures don't pass anything
-	// if r == nil {
-	// 	return
-	// }
-
 	b, err := io.ReadAll(r)
 	rc = &readCloser{c: r, r: bytes.NewReader(b), e: err}
 

--- a/event.go
+++ b/event.go
@@ -5,8 +5,12 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
+	"math"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -42,12 +46,18 @@ var clock = time.Now
 
 func newRequest(id string, r *http.Request, options *Options) *request {
 	var body any
+
+	if r.Body == nil {
+		r.Body = http.NoBody
+	}
+
 	if options.RecordRequestBody {
 		body, r.Body = duplicateBody(r.Body)
+		body = redactValues(body, options.IncludeSpecifiedRequestBodyKeys)
 	}
 	req := &request{
 		ID:          id,
-		Headers:     formatHeaders(r.Header, options.RedactHeaders),
+		Headers:     formatHeaders(r.Header, options.IncludeSpecifiedRequestHeaderKeys),
 		Method:      r.Method,
 		URL:         r.URL.String(),
 		Path:        r.URL.Path,
@@ -70,11 +80,18 @@ func newResponse(res *http.Response, err error, options *Options) *response {
 		}
 	}
 	var body any
+
+	// Throwing an error on network failures causes duplicateBody to segfault on nil
+	if res.Body == nil {
+		res.Body = http.NoBody
+	}
+
 	if options.RecordResponseBody {
 		body, res.Body = duplicateBody(res.Body)
+		body = redactValues(body, options.IncludeSpecifiedResponseBodyKeys)
 	}
 	return &response{
-		Headers:     formatHeaders(res.Header, options.RedactHeaders),
+		Headers:     headersToMap(res.Header),
 		Status:      res.StatusCode,
 		StatusText:  res.Status,
 		RespondedAt: now,
@@ -82,11 +99,19 @@ func newResponse(res *http.Response, err error, options *Options) *response {
 	}
 }
 
-func formatHeaders(h http.Header, redact map[string]bool) map[string]string {
+func headersToMap(h http.Header) map[string]string {
+	ret := map[string]string{}
+	for k, vs := range h {
+		ret[k] = strings.Join(vs, ", ")
+	}
+	return ret
+}
+
+func formatHeaders(h http.Header, includedKeys map[string]bool) map[string]string {
 	ret := map[string]string{}
 	for k, vs := range h {
 		v := strings.Join(vs, ", ")
-		if redact[strings.ToLower(k)] {
+		if !includedKeys[strings.ToLower(k)] {
 			sha := sha1.Sum([]byte(v))
 			ret[k] = "redacted:" + hex.EncodeToString(sha[:])
 		} else {
@@ -94,6 +119,81 @@ func formatHeaders(h http.Header, redact map[string]bool) map[string]string {
 		}
 	}
 	return ret
+}
+
+func redactValues(b any, includedKeys map[string]bool) any {
+	lowerCase := regexp.MustCompile("[a-z]")
+	upperCase := regexp.MustCompile("[A-Z]")
+	numeric := regexp.MustCompile("[0-9]")
+	special := regexp.MustCompile("[^a-zA-Z0-9\\s]")
+
+	var redactInt = func(i int) int {
+		s := strconv.Itoa(i)
+		s = numeric.ReplaceAllString(s, "1")
+		i, _ = strconv.Atoi(s)
+		return i
+	}
+
+	switch b := b.(type) {
+	case map[string]any:
+		for k, v := range b {
+			if includedKeys[k] {
+				b[k] = v
+			} else {
+				b[k] = redactValues(v, includedKeys)
+			}
+		}
+		return b
+	case []any:
+		for i, v := range b {
+			b[i] = redactValues(v, includedKeys)
+		}
+		return b
+	case []uint8:
+		return "binary"
+	case string:
+		b = upperCase.ReplaceAllString(b, "A")
+		b = lowerCase.ReplaceAllString(b, "a")
+		b = numeric.ReplaceAllString(b, "1")
+		b = special.ReplaceAllString(b, "*")
+		return b
+	case bool:
+		b = false
+		return b
+	case int:
+		b = redactInt(b)
+		return b
+	case float64:
+		if b == math.Trunc(b) {
+			b = float64(redactInt(int(b)))
+			return b
+		} else {
+			s := fmt.Sprintf("%f", b)
+			s = numeric.ReplaceAllString(s, "1")
+			b, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				b = 0
+			}
+			return b
+		}
+	case float32:
+		if float64(b) == math.Trunc(float64(b)) {
+			return float32(redactInt(int(b)))
+		} else {
+			s := fmt.Sprintf("%f", b)
+			s = numeric.ReplaceAllString(s, "1")
+			f, err := strconv.ParseFloat(s, 32)
+			if err != nil {
+				b = 0
+			}
+			b = float32(f)
+			return b
+		}
+	case nil:
+		return nil
+	default:
+		return "?"
+	}
 }
 
 type readCloser struct {
@@ -114,8 +214,12 @@ func (rc *readCloser) Close() error {
 }
 
 func duplicateBody(r io.ReadCloser) (body any, rc io.ReadCloser) {
-	b, err := io.ReadAll(r)
+	// Network error failures don't pass anything
+	// if r == nil {
+	// 	return
+	// }
 
+	b, err := io.ReadAll(r)
 	rc = &readCloser{c: r, r: bytes.NewReader(b), e: err}
 
 	if !utf8.Valid(b) {

--- a/options.go
+++ b/options.go
@@ -22,10 +22,6 @@ type Options struct {
 	// or "https://dashboard.supergood.ai" if not set)
 	BaseURL string
 
-	// DisableDefaultClient disables Supergood overriding http.DefaultClient
-	// (defaults to false)
-	DisableDefaultClient bool
-
 	// RecordRequestBody additionally sends the body of requests to supergood for debugging.
 	// Defaults to false, if set true all values will be redacted and hashed unless specified
 	RecordRequestBody bool

--- a/options_test.go
+++ b/options_test.go
@@ -43,7 +43,6 @@ func TestOptions_overrides(t *testing.T) {
 		BaseURL:                           "https://dashboard.superbad.ai",
 		RecordRequestBody:                 true,
 		RecordResponseBody:                true,
-		DisableDefaultClient:              true,
 		IncludeSpecifiedResponseBodyKeys:  map[string]bool{"foo": true},
 		IncludeSpecifiedRequestBodyKeys:   map[string]bool{"bar": true},
 		IncludeSpecifiedRequestHeaderKeys: map[string]bool{"authz": true},
@@ -60,7 +59,6 @@ func TestOptions_overrides(t *testing.T) {
 	require.Equal(t, "https://dashboard.superbad.ai", o.BaseURL)
 	require.True(t, o.RecordRequestBody)
 	require.True(t, o.RecordResponseBody)
-	require.True(t, o.DisableDefaultClient)
 	require.False(t, o.IncludeSpecifiedRequestHeaderKeys["authorization"])
 	require.True(t, o.IncludeSpecifiedRequestHeaderKeys["authz"])
 	require.True(t, o.IncludeSpecifiedResponseBodyKeys["foo"])

--- a/options_test.go
+++ b/options_test.go
@@ -84,4 +84,6 @@ func TestOptions_errors(t *testing.T) {
 		require.Error(t, err)
 	}
 
+	_, err := New(&Options{AllowedDomains: []string{"superbad.ai"}})
+	require.Error(t, err)
 }

--- a/options_test.go
+++ b/options_test.go
@@ -43,6 +43,7 @@ func TestOptions_overrides(t *testing.T) {
 		BaseURL:                           "https://dashboard.superbad.ai",
 		RecordRequestBody:                 true,
 		RecordResponseBody:                true,
+		DisableDefaultClient:              true,
 		IncludeSpecifiedResponseBodyKeys:  map[string]bool{"foo": true},
 		IncludeSpecifiedRequestBodyKeys:   map[string]bool{"bar": true},
 		IncludeSpecifiedRequestHeaderKeys: map[string]bool{"authz": true},
@@ -59,6 +60,7 @@ func TestOptions_overrides(t *testing.T) {
 	require.Equal(t, "https://dashboard.superbad.ai", o.BaseURL)
 	require.True(t, o.RecordRequestBody)
 	require.True(t, o.RecordResponseBody)
+	require.True(t, o.DisableDefaultClient)
 	require.False(t, o.IncludeSpecifiedRequestHeaderKeys["authorization"])
 	require.True(t, o.IncludeSpecifiedRequestHeaderKeys["authz"])
 	require.True(t, o.IncludeSpecifiedResponseBodyKeys["foo"])

--- a/supergood.go
+++ b/supergood.go
@@ -101,16 +101,6 @@ func (sg *Service) logResponse(id string, resp *response) {
 	}
 }
 
-// func (sg *Service) logDebug(e *event) {
-// 	if sg.options.LogLevel == "debug" {
-// 		b, err := json.MarshalIndent((*e), "", "  ")
-// 		if err != nil {
-// 			fmt.Println(err)
-// 		}
-// 		fmt.Print(string(b))
-// 	}
-// }
-
 func (sg *Service) loop() {
 	var closed chan error
 	for {

--- a/supergood.go
+++ b/supergood.go
@@ -52,8 +52,10 @@ func New(o *Options) (*Service, error) {
 
 	sg.DefaultClient = sg.Wrap(http.DefaultClient)
 
-	// Overrides default client
-	http.DefaultClient = sg.DefaultClient
+	// Overrides default client to use on all requests
+	if !o.DisableDefaultClient {
+		http.DefaultClient = sg.DefaultClient
+	}
 
 	sg.reset()
 	go sg.loop()

--- a/supergood.go
+++ b/supergood.go
@@ -51,6 +51,10 @@ func New(o *Options) (*Service, error) {
 	}
 
 	sg.DefaultClient = sg.Wrap(http.DefaultClient)
+
+	// Overrides default client
+	http.DefaultClient = sg.DefaultClient
+
 	sg.reset()
 	go sg.loop()
 	return sg, nil
@@ -97,6 +101,16 @@ func (sg *Service) logResponse(id string, resp *response) {
 	}
 }
 
+// func (sg *Service) logDebug(e *event) {
+// 	if sg.options.LogLevel == "debug" {
+// 		b, err := json.MarshalIndent((*e), "", "  ")
+// 		if err != nil {
+// 			fmt.Println(err)
+// 		}
+// 		fmt.Print(string(b))
+// 	}
+// }
+
 func (sg *Service) loop() {
 	var closed chan error
 	for {
@@ -123,7 +137,6 @@ func (sg *Service) loop() {
 
 func (sg *Service) flush(force bool) error {
 	entries := sg.reset()
-
 	toSend := []*event{}
 
 	for _, entry := range entries {
@@ -136,7 +149,6 @@ func (sg *Service) flush(force bool) error {
 	if len(toSend) == 0 {
 		return nil
 	}
-
 	return sg.post("/api/events", toSend)
 }
 

--- a/supergood.go
+++ b/supergood.go
@@ -29,6 +29,7 @@ type Service struct {
 	// DefaultClient is a wrapped version of http.DefaultClient
 	// If you'd like to use supergood on all requests, set
 	// http.DefaultClient = sg.DefaultClient.
+
 	DefaultClient *http.Client
 
 	options *Options
@@ -51,11 +52,6 @@ func New(o *Options) (*Service, error) {
 	}
 
 	sg.DefaultClient = sg.Wrap(http.DefaultClient)
-
-	// Overrides default client to use on all requests
-	if !o.DisableDefaultClient {
-		http.DefaultClient = sg.DefaultClient
-	}
 
 	sg.reset()
 	go sg.loop()

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -183,8 +183,8 @@ func Test_Supergood(t *testing.T) {
 		reset()
 		sg, err := New(&Options{AllowedDomains: allowedDomains})
 		require.NoError(t, err)
-		_, err = sg.DefaultClient.Get(allowedUrl)
-		_, err = sg.DefaultClient.Get("https://api64.ipify.org/?format=json")
+		sg.DefaultClient.Get(allowedUrl)
+		sg.DefaultClient.Get("https://api64.ipify.org/?format=json")
 
 		require.NoError(t, sg.Close())
 		require.Len(t, events, 1)

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -152,7 +152,7 @@ func Test_Supergood(t *testing.T) {
 	}
 
 	t.Run("default", func(t *testing.T) {
-		echo(t, &Options{RecordResponseBody: false})
+		echo(t, &Options{RecordResponseBody: false, DisableDefaultClient: true})
 		require.Len(t, events, 1)
 		require.Nil(t, events[0].Response.Body)
 		require.Nil(t, events[0].Request.Body)
@@ -167,12 +167,12 @@ func Test_Supergood(t *testing.T) {
 	})
 
 	t.Run("RecordResponseBody=true", func(t *testing.T) {
-		echo(t, &Options{RecordResponseBody: true})
+		echo(t, &Options{RecordResponseBody: true, DisableDefaultClient: true})
 		require.Len(t, events, 1)
 		require.Equal(t, "aaaa*aaaa", events[0].Response.Body)
 	})
 	t.Run("RecordRequestBody=true", func(t *testing.T) {
-		echo(t, &Options{RecordRequestBody: true})
+		echo(t, &Options{RecordRequestBody: true, DisableDefaultClient: true})
 		require.Len(t, events, 1)
 		require.Equal(t, "aaaa*aaaa", events[0].Request.Body)
 	})
@@ -193,68 +193,68 @@ func Test_Supergood(t *testing.T) {
 	})
 
 	t.Run("redacting nested string values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": "aaaaa"}, "other": "aaaaa"}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested integer values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":999},"other":999}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":999},"other":999}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": float64(111)}, "other": float64(111)}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested float values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":999.99},"other":999.99}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":999.99},"other":999.99}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": 111.111111}, "other": 111.111111}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested array values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":[{"key":"value"}],"other":["value"]}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":[{"key":"value"}],"other":["value"]}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": []any{map[string]any{"key": "aaaaa"}}, "other": []any{"aaaaa"}}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested boolean values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":true},"other":true}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":true},"other":true}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": false}, "other": false}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested non-ASCII values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":"สวัสดี"},"other":"ลาก่อน"}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":"สวัสดี"},"other":"ลาก่อน"}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": "******"}, "other": "******"}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nil values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key": null},"other": null}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key": null},"other": null}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": nil}, "other": nil}, events[0].Request.Body)
 	})
 
 	t.Run("ignoring redaction for nested request keys", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, IncludeSpecifiedRequestBodyKeys: map[string]bool{"key": true}}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true, IncludeSpecifiedRequestBodyKeys: map[string]bool{"key": true}}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": "value"}, "other": "aaaaa"}, events[0].Request.Body)
 	})
 
 	t.Run("valid JSON body", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"ok":200}`))
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"ok":200}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"ok": float64(111)}, events[0].Request.Body)
 	})
 
 	t.Run("binary body", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true}, []byte{0xff, 0x00, 0xff, 0x00})
+		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte{0xff, 0x00, 0xff, 0x00})
 		require.Len(t, events, 1)
 		// String = "/wD/AA=="
 		require.Equal(t, "binary", events[0].Request.Body)
 	})
 
 	t.Run("RedactHeaders", func(t *testing.T) {
-		echo(t, &Options{IncludeSpecifiedRequestHeaderKeys: map[string]bool{"AUTH-WAS": true}})
+		echo(t, &Options{IncludeSpecifiedRequestHeaderKeys: map[string]bool{"AUTH-WAS": true}, DisableDefaultClient: true})
 		require.Len(t, events, 1)
 		require.Equal(t, events[0].Request.Headers["Authorization"], "redacted:dba430468af6b5fc3c22facf6dc871ce6e3801b9")
 		require.Equal(t, events[0].Response.Headers["Auth-Was"], "test-auth")
@@ -268,6 +268,7 @@ func Test_Supergood(t *testing.T) {
 				}
 				return true
 			},
+			DisableDefaultClient: true,
 		})
 		require.Len(t, events, 0)
 	})
@@ -275,7 +276,7 @@ func Test_Supergood(t *testing.T) {
 	t.Run("test timing", func(t *testing.T) {
 		clock = func() time.Time { return time.Date(2023, 01, 01, 01, 01, 01, 0, time.UTC) }
 		defer func() { clock = time.Now }()
-		echoBody(t, nil, []byte("set-clock"))
+		echoBody(t, &Options{DisableDefaultClient: true}, []byte("set-clock"))
 
 		require.Equal(t, time.Date(2023, 01, 01, 01, 01, 01, 0, time.UTC), events[0].Request.RequestedAt)
 		require.Equal(t, time.Date(2023, 01, 01, 01, 01, 03, 0, time.UTC), events[0].Response.RespondedAt)
@@ -299,7 +300,7 @@ func Test_Supergood(t *testing.T) {
 
 	t.Run("error handling on response body parsing", func(t *testing.T) {
 		reset()
-		sg, err := New(&Options{RecordResponseBody: true})
+		sg, err := New(&Options{RecordResponseBody: true, DisableDefaultClient: true})
 		require.NoError(t, err)
 		defer sg.Close()
 
@@ -324,7 +325,7 @@ func Test_Supergood(t *testing.T) {
 
 	t.Run("test flush", func(t *testing.T) {
 		reset()
-		sg, err := New(&Options{FlushInterval: 1 * time.Millisecond})
+		sg, err := New(&Options{FlushInterval: 1 * time.Millisecond, DisableDefaultClient: true})
 		require.NoError(t, err)
 		defer sg.Close()
 		sg.DefaultClient.Get(host + "/echo")
@@ -337,7 +338,7 @@ func Test_Supergood(t *testing.T) {
 	t.Run("error handling on close", func(t *testing.T) {
 		broken = true
 		defer func() { broken = false }()
-		echo(t, nil)
+		echo(t, &Options{DisableDefaultClient: true})
 		require.Len(t, errors, 1)
 		require.Equal(t, "supergood: got HTTP 500 Internal Server Error posting to /api/events", errors[0].Message)
 		require.Equal(t, "supergood-go", errors[0].Payload.Name)
@@ -350,7 +351,7 @@ func Test_Supergood(t *testing.T) {
 		twiceBroken = true
 		defer func() { twiceBroken = false }()
 		var logErr error
-		sg, err := New(&Options{OnError: func(e error) { logErr = e }})
+		sg, err := New(&Options{OnError: func(e error) { logErr = e }, DisableDefaultClient: true})
 		require.NoError(t, err)
 		sg.DefaultClient.Get(host + "/echo")
 
@@ -361,7 +362,7 @@ func Test_Supergood(t *testing.T) {
 
 	t.Run("handling invalid client id", func(t *testing.T) {
 		var logErr error
-		sg, err := New(&Options{OnError: func(e error) { logErr = e }, ClientID: "oops"})
+		sg, err := New(&Options{OnError: func(e error) { logErr = e }, ClientID: "oops", DisableDefaultClient: true})
 		require.NoError(t, err)
 		sg.DefaultClient.Get(host + "/echo")
 		err = sg.Close()

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -152,7 +152,7 @@ func Test_Supergood(t *testing.T) {
 	}
 
 	t.Run("default", func(t *testing.T) {
-		echo(t, &Options{RecordResponseBody: false, DisableDefaultClient: true})
+		echo(t, &Options{RecordResponseBody: false})
 		require.Len(t, events, 1)
 		require.Nil(t, events[0].Response.Body)
 		require.Nil(t, events[0].Request.Body)
@@ -167,12 +167,12 @@ func Test_Supergood(t *testing.T) {
 	})
 
 	t.Run("RecordResponseBody=true", func(t *testing.T) {
-		echo(t, &Options{RecordResponseBody: true, DisableDefaultClient: true})
+		echo(t, &Options{RecordResponseBody: true})
 		require.Len(t, events, 1)
 		require.Equal(t, "aaaa*aaaa", events[0].Response.Body)
 	})
 	t.Run("RecordRequestBody=true", func(t *testing.T) {
-		echo(t, &Options{RecordRequestBody: true, DisableDefaultClient: true})
+		echo(t, &Options{RecordRequestBody: true})
 		require.Len(t, events, 1)
 		require.Equal(t, "aaaa*aaaa", events[0].Request.Body)
 	})
@@ -193,68 +193,68 @@ func Test_Supergood(t *testing.T) {
 	})
 
 	t.Run("redacting nested string values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": "aaaaa"}, "other": "aaaaa"}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested integer values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":999},"other":999}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":999},"other":999}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": float64(111)}, "other": float64(111)}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested float values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":999.99},"other":999.99}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":999.99},"other":999.99}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": 111.111111}, "other": 111.111111}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested array values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":[{"key":"value"}],"other":["value"]}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":[{"key":"value"}],"other":["value"]}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": []any{map[string]any{"key": "aaaaa"}}, "other": []any{"aaaaa"}}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested boolean values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":true},"other":true}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":true},"other":true}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": false}, "other": false}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nested non-ASCII values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key":"สวัสดี"},"other":"ลาก่อน"}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key":"สวัสดี"},"other":"ลาก่อน"}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": "******"}, "other": "******"}, events[0].Request.Body)
 	})
 
 	t.Run("redacting nil values", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"nested":{"key": null},"other": null}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"nested":{"key": null},"other": null}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": nil}, "other": nil}, events[0].Request.Body)
 	})
 
 	t.Run("ignoring redaction for nested request keys", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true, IncludeSpecifiedRequestBodyKeys: map[string]bool{"key": true}}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
+		echoBody(t, &Options{RecordRequestBody: true, IncludeSpecifiedRequestBodyKeys: map[string]bool{"key": true}}, []byte(`{"nested":{"key":"value"},"other":"value"}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"nested": map[string]any{"key": "value"}, "other": "aaaaa"}, events[0].Request.Body)
 	})
 
 	t.Run("valid JSON body", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte(`{"ok":200}`))
+		echoBody(t, &Options{RecordRequestBody: true}, []byte(`{"ok":200}`))
 		require.Len(t, events, 1)
 		require.Equal(t, map[string]any{"ok": float64(111)}, events[0].Request.Body)
 	})
 
 	t.Run("binary body", func(t *testing.T) {
-		echoBody(t, &Options{RecordRequestBody: true, DisableDefaultClient: true}, []byte{0xff, 0x00, 0xff, 0x00})
+		echoBody(t, &Options{RecordRequestBody: true}, []byte{0xff, 0x00, 0xff, 0x00})
 		require.Len(t, events, 1)
 		// String = "/wD/AA=="
 		require.Equal(t, "binary", events[0].Request.Body)
 	})
 
 	t.Run("RedactHeaders", func(t *testing.T) {
-		echo(t, &Options{IncludeSpecifiedRequestHeaderKeys: map[string]bool{"AUTH-WAS": true}, DisableDefaultClient: true})
+		echo(t, &Options{IncludeSpecifiedRequestHeaderKeys: map[string]bool{"AUTH-WAS": true}})
 		require.Len(t, events, 1)
 		require.Equal(t, events[0].Request.Headers["Authorization"], "redacted:dba430468af6b5fc3c22facf6dc871ce6e3801b9")
 		require.Equal(t, events[0].Response.Headers["Auth-Was"], "test-auth")
@@ -268,7 +268,6 @@ func Test_Supergood(t *testing.T) {
 				}
 				return true
 			},
-			DisableDefaultClient: true,
 		})
 		require.Len(t, events, 0)
 	})
@@ -276,7 +275,7 @@ func Test_Supergood(t *testing.T) {
 	t.Run("test timing", func(t *testing.T) {
 		clock = func() time.Time { return time.Date(2023, 01, 01, 01, 01, 01, 0, time.UTC) }
 		defer func() { clock = time.Now }()
-		echoBody(t, &Options{DisableDefaultClient: true}, []byte("set-clock"))
+		echoBody(t, &Options{}, []byte("set-clock"))
 
 		require.Equal(t, time.Date(2023, 01, 01, 01, 01, 01, 0, time.UTC), events[0].Request.RequestedAt)
 		require.Equal(t, time.Date(2023, 01, 01, 01, 01, 03, 0, time.UTC), events[0].Response.RespondedAt)
@@ -300,7 +299,7 @@ func Test_Supergood(t *testing.T) {
 
 	t.Run("error handling on response body parsing", func(t *testing.T) {
 		reset()
-		sg, err := New(&Options{RecordResponseBody: true, DisableDefaultClient: true})
+		sg, err := New(&Options{RecordResponseBody: true})
 		require.NoError(t, err)
 		defer sg.Close()
 
@@ -325,7 +324,7 @@ func Test_Supergood(t *testing.T) {
 
 	t.Run("test flush", func(t *testing.T) {
 		reset()
-		sg, err := New(&Options{FlushInterval: 1 * time.Millisecond, DisableDefaultClient: true})
+		sg, err := New(&Options{FlushInterval: 1 * time.Millisecond})
 		require.NoError(t, err)
 		defer sg.Close()
 		sg.DefaultClient.Get(host + "/echo")
@@ -338,7 +337,7 @@ func Test_Supergood(t *testing.T) {
 	t.Run("error handling on close", func(t *testing.T) {
 		broken = true
 		defer func() { broken = false }()
-		echo(t, &Options{DisableDefaultClient: true})
+		echo(t, &Options{})
 		require.Len(t, errors, 1)
 		require.Equal(t, "supergood: got HTTP 500 Internal Server Error posting to /api/events", errors[0].Message)
 		require.Equal(t, "supergood-go", errors[0].Payload.Name)
@@ -351,7 +350,7 @@ func Test_Supergood(t *testing.T) {
 		twiceBroken = true
 		defer func() { twiceBroken = false }()
 		var logErr error
-		sg, err := New(&Options{OnError: func(e error) { logErr = e }, DisableDefaultClient: true})
+		sg, err := New(&Options{OnError: func(e error) { logErr = e }})
 		require.NoError(t, err)
 		sg.DefaultClient.Get(host + "/echo")
 
@@ -362,7 +361,7 @@ func Test_Supergood(t *testing.T) {
 
 	t.Run("handling invalid client id", func(t *testing.T) {
 		var logErr error
-		sg, err := New(&Options{OnError: func(e error) { logErr = e }, ClientID: "oops", DisableDefaultClient: true})
+		sg, err := New(&Options{OnError: func(e error) { logErr = e }, ClientID: "oops"})
 		require.NoError(t, err)
 		sg.DefaultClient.Get(host + "/echo")
 		err = sg.Close()

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -189,7 +189,7 @@ func Test_Supergood(t *testing.T) {
 		require.NoError(t, sg.Close())
 		require.Len(t, events, 1)
 		require.Equal(t, allowedUrl, events[0].Request.URL)
-		echo(t, &Options{AllowedDomains: allowedDomains})
+		// echo(t, &Options{AllowedDomains: allowedDomains})
 	})
 
 	t.Run("redacting nested string values", func(t *testing.T) {


### PR DESCRIPTION
Adding the ability to include request and response body, but have all the values redacted by default. Give the user the option to specify keys to un-redact.

Using a redaction method that saves the length, data type and general shape of the values without exposing any sensitive information. Hopefully this is enough information to perform billing calculations on the specified API's as well as light debugging.