### PR TITLE
[Feature] Update supergood client options to allow to pass a base client

### DIFF
--- a/supergood.go
+++ b/supergood.go
@@ -51,7 +51,12 @@ func New(o *Options) (*Service, error) {
 		close:   make(chan chan error),
 	}
 
-	sg.DefaultClient = sg.Wrap(http.DefaultClient)
+	client := http.DefaultClient
+	if sg.options.HTTPClient != nil {
+		client = sg.options.HTTPClient
+	}
+
+	sg.DefaultClient = sg.Wrap(client)
 
 	sg.reset()
 	go sg.loop()
@@ -201,6 +206,7 @@ func (sg *Service) post(path string, body any) error {
 	}
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(sg.options.ClientID+":"+sg.options.ClientSecret)))
 	req.Header.Set("Content-Type", "application/json")
+
 	resp, err := sg.options.HTTPClient.Do(req)
 	if err != nil {
 		return err

--- a/supergood.go
+++ b/supergood.go
@@ -206,7 +206,6 @@ func (sg *Service) post(path string, body any) error {
 	}
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(sg.options.ClientID+":"+sg.options.ClientSecret)))
 	req.Header.Set("Content-Type", "application/json")
-
 	resp, err := sg.options.HTTPClient.Do(req)
 	if err != nil {
 		return err

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -19,8 +19,6 @@ var errors []*errorReport
 var broken bool
 var twiceBroken bool
 
-//var clientChannel = make(chan int)
-
 func reset() {
 	events = []*event{}
 	errors = []*errorReport{}

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -210,7 +210,6 @@ func Test_Supergood(t *testing.T) {
 		require.NoError(t, sg.Close())
 		require.Len(t, events, 1)
 		require.Equal(t, allowedUrl, events[0].Request.URL)
-		// echo(t, &Options{AllowedDomains: allowedDomains})
 	})
 
 	t.Run("redacting nested string values", func(t *testing.T) {
@@ -425,7 +424,8 @@ func Test_Supergood(t *testing.T) {
 		mockBaseClient := &http.Client{}
 		mockServerChannel := make(chan int, 2)
 		options := &Options{
-			HTTPClient: mockWrapClient(mockBaseClient, mockServerChannel),
+			HTTPClient:         mockWrapClient(mockBaseClient, mockServerChannel),
+			RecordResponseBody: true,
 		}
 		echo(t, options)
 
@@ -438,5 +438,8 @@ func Test_Supergood(t *testing.T) {
 		// and another tracking the call to the supergood backend
 		require.Equal(t, count, 2)
 		close(mockServerChannel)
+
+		require.Len(t, events, 1)
+		require.Equal(t, "aaaa*aaaa", events[0].Response.Body)
 	})
 }


### PR DESCRIPTION
Some client are requesting the ability to have the supergood client wrap existing wrapped clients. Common usecase is for wrapped datadog clients for tracing http requests.