### PR TITLE
[Feature] Include option to not redact event payload when sending to Supergood

### DIFF
--- a/event.go
+++ b/event.go
@@ -49,7 +49,9 @@ func newRequest(id string, r *http.Request, options *Options) *request {
 
 	if options.RecordRequestBody {
 		body, r.Body = duplicateBody(r.Body)
-		body = redactValues(body, options.IncludeSpecifiedRequestBodyKeys)
+		if !options.SkipRedaction {
+			body = redactValues(body, options.IncludeSpecifiedRequestBodyKeys)
+		}
 	}
 	req := &request{
 		ID:          id,
@@ -84,7 +86,9 @@ func newResponse(res *http.Response, err error, options *Options) *response {
 
 	if options.RecordResponseBody {
 		body, res.Body = duplicateBody(res.Body)
-		body = redactValues(body, options.IncludeSpecifiedResponseBodyKeys)
+		if !options.SkipRedaction {
+			body = redactValues(body, options.IncludeSpecifiedResponseBodyKeys)
+		}
 	}
 	return &response{
 		Headers:     headersToMap(res.Header),

--- a/options.go
+++ b/options.go
@@ -31,6 +31,10 @@ type Options struct {
 	// (defaults to an empty map)
 	IncludeSpecifiedRequestBodyKeys map[string]bool
 
+	// SkipRedaction allows content from an event payload to be passed to the supergood system for
+	// finer grain anomoly detection
+	SkipRedaction bool
+
 	// RecordResponseBody additionally sends the body of responses to supergood for debugging.
 	// Defaults to false, if set true all values will be redacted and hashed unless specified
 	RecordResponseBody bool

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -442,4 +442,10 @@ func Test_Supergood(t *testing.T) {
 		require.Len(t, events, 1)
 		require.Equal(t, "aaaa*aaaa", events[0].Response.Body)
 	})
+
+	t.Run("SkipRedaction=true", func(t *testing.T) {
+		echo(t, &Options{RecordResponseBody: true, SkipRedaction: true})
+		require.Len(t, events, 1)
+		require.Equal(t, "test-body", events[0].Response.Body)
+	})
 }

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -444,8 +444,9 @@ func Test_Supergood(t *testing.T) {
 	})
 
 	t.Run("SkipRedaction=true", func(t *testing.T) {
-		echo(t, &Options{RecordResponseBody: true, SkipRedaction: true})
+		echo(t, &Options{RecordResponseBody: true, RecordRequestBody: true, SkipRedaction: true})
 		require.Len(t, events, 1)
+		require.Equal(t, "test-body", events[0].Request.Body)
 		require.Equal(t, "test-body", events[0].Response.Body)
 	})
 }


### PR DESCRIPTION
Description: To allow for future anomaly detection capabilities, allow the option to skip the default redaction 