### PR TITLE
[Bug]: Updating cache flush

### DIFF
--- a/supergood.go
+++ b/supergood.go
@@ -127,15 +127,19 @@ func (sg *Service) loop() {
 }
 
 func (sg *Service) flush(force bool) error {
-	entries := sg.reset()
-	toSend := []*event{}
+	sg.mutex.Lock()
+	defer sg.mutex.Unlock()
 
-	for _, entry := range entries {
+	toSend := []*event{}
+	for key, entry := range sg.queue {
 		if entry.Response == nil && !force {
 			continue
 		}
+		delete(sg.queue, key)
 		toSend = append(toSend, entry)
 	}
+	fmt.Printf("queue-length: %d\n", len(sg.queue))
+	fmt.Printf("flushing: %d\n", len(toSend))
 
 	if len(toSend) == 0 {
 		return nil

--- a/supergood.go
+++ b/supergood.go
@@ -138,8 +138,6 @@ func (sg *Service) flush(force bool) error {
 		delete(sg.queue, key)
 		toSend = append(toSend, entry)
 	}
-	fmt.Printf("queue-length: %d\n", len(sg.queue))
-	fmt.Printf("flushing: %d\n", len(toSend))
 
 	if len(toSend) == 0 {
 		return nil


### PR DESCRIPTION
Description:
Current logic: If no response is cached for event and flush is invoked, clear the entire cache.
New logic : Retain any event in cache that does not have an associated response regardless if flush is invoked. 