### PR TITLE
[Internal]: Handle failed remote config initialization

### DIFF
--- a/internal/remote-config/cache.go
+++ b/internal/remote-config/cache.go
@@ -27,7 +27,7 @@ func (rc *RemoteConfig) Set(domain string, val map[string]EndpointCacheVal) erro
 }
 
 func (rc *RemoteConfig) IsInitialized() bool {
-	return rc.cache == nil
+	return rc.initialized
 }
 
 // Create takes in the response body marshalled from the /config request and

--- a/internal/remote-config/cache.go
+++ b/internal/remote-config/cache.go
@@ -26,11 +26,14 @@ func (rc *RemoteConfig) Set(domain string, val map[string]EndpointCacheVal) erro
 	return nil
 }
 
+func (rc *RemoteConfig) IsInitialized() bool {
+	return rc.cache == nil
+}
+
 // Create takes in the response body marshalled from the /config request and
 // creates a remote config cache object used by supergood client to ignore/allow requests and
 // to redact sensitive keys
 func (rc *RemoteConfig) Create(remoteConfigArray []RemoteConfigResponse) error {
-	remoteConfigMap := map[string]map[string]EndpointCacheVal{}
 	for _, config := range remoteConfigArray {
 		cacheVal := map[string]EndpointCacheVal{}
 		for _, endpoint := range config.Endpoints {
@@ -54,7 +57,6 @@ func (rc *RemoteConfig) Create(remoteConfigArray []RemoteConfigResponse) error {
 		if err != nil {
 			return err
 		}
-		remoteConfigMap[config.Domain] = cacheVal
 	}
 	return nil
 }

--- a/internal/remote-config/remoteconfig.go
+++ b/internal/remote-config/remoteconfig.go
@@ -25,11 +25,8 @@ func New(opts RemoteConfigOpts) RemoteConfig {
 // Init initializes the remote config cache
 // Does not return an error - do not want to prevent client app from starting
 // due to a failed config fetch from supergood
-func (rc *RemoteConfig) Init() {
-	err := rc.fetchAndSetConfig()
-	if err != nil {
-		rc.handleError(err)
-	}
+func (rc *RemoteConfig) Init() error {
+	return rc.fetchAndSetConfig()
 }
 
 // RefreshRemoteConfig refreshes the remote config on an interval
@@ -56,7 +53,7 @@ func (rc *RemoteConfig) fetchAndSetConfig() error {
 	}
 
 	err = rc.Create(resp)
-	if err != nil {
+	if err == nil {
 		rc.initialized = true
 	}
 

--- a/internal/remote-config/remoteconfig.go
+++ b/internal/remote-config/remoteconfig.go
@@ -14,6 +14,7 @@ func New(opts RemoteConfigOpts) RemoteConfig {
 		client:                  opts.Client,
 		close:                   make(chan struct{}),
 		fetchInterval:           opts.FetchInterval,
+		initialized:             false,
 		handleError:             opts.HandleError,
 		redactRequestBodyKeys:   opts.RedactRequestBodyKeys,
 		redactResponseBodyKeys:  opts.RedactResponseBodyKeys,
@@ -22,8 +23,13 @@ func New(opts RemoteConfigOpts) RemoteConfig {
 }
 
 // Init initializes the remote config cache
-func (rc *RemoteConfig) Init() error {
-	return rc.fetchAndSetConfig()
+// Does not return an error - do not want to prevent client app from starting
+// due to a failed config fetch from supergood
+func (rc *RemoteConfig) Init() {
+	err := rc.fetchAndSetConfig()
+	if err != nil {
+		rc.handleError(err)
+	}
 }
 
 // RefreshRemoteConfig refreshes the remote config on an interval
@@ -49,5 +55,10 @@ func (rc *RemoteConfig) fetchAndSetConfig() error {
 		return err
 	}
 
-	return rc.Create(resp)
+	err = rc.Create(resp)
+	if err != nil {
+		rc.initialized = true
+	}
+
+	return err
 }

--- a/internal/remote-config/types.go
+++ b/internal/remote-config/types.go
@@ -27,6 +27,7 @@ type RemoteConfig struct {
 	client                  *http.Client
 	close                   chan struct{}
 	fetchInterval           time.Duration
+	initialized             bool
 	handleError             func(error)
 	mutex                   sync.RWMutex
 	redactRequestBodyKeys   map[string][]string

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -26,8 +26,9 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// Do not forward to supergood if the request is not in the list of user provided
-	// selected requests OR if the request is ignored by the supergood remote config
-	if !rt.sg.options.SelectRequests(req) || endpointAction == "Ignore" {
+	// selected requests OR if the request is ignored by the supergood remote config OR if
+	// remote config is not initialized
+	if !rt.sg.options.SelectRequests(req) || endpointAction == "Ignore" || !rt.sg.rc.IsInitialized() {
 		return rt.next.RoundTrip(req)
 	}
 

--- a/supergood.go
+++ b/supergood.go
@@ -80,7 +80,10 @@ func New(o *Options) (*Service, error) {
 	})
 
 	sg.reset()
-	sg.rc.Init()
+	err = sg.rc.Init()
+	if err != nil {
+		sg.handleError(err)
+	}
 
 	go sg.loop()
 	go sg.rc.Refresh()

--- a/supergood.go
+++ b/supergood.go
@@ -80,13 +80,7 @@ func New(o *Options) (*Service, error) {
 	})
 
 	sg.reset()
-
-	// TODO: dont error on remote config initalization
-	// Do not send events unless we've successfully fetched remote config
-	err = sg.rc.Init()
-	if err != nil {
-		return nil, err
-	}
+	sg.rc.Init()
 
 	go sg.loop()
 	go sg.rc.Refresh()

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -351,17 +351,19 @@ func Test_Supergood(t *testing.T) {
 	t.Run("handling invalid client id", func(t *testing.T) {
 		var logErr error
 		_, err := New(&Options{OnError: func(e error) { logErr = e }, ClientID: "oops"})
-		require.Error(t, err, "invalid ClientID")
-		require.NoError(t, logErr)
+		require.NoError(t, err)
+		require.Error(t, logErr, "invalid ClientID")
 	})
 
 	t.Run("handling broken base url", func(t *testing.T) {
-
+		var logErr error
 		_, err := New(&Options{
 			BaseURL:       "https://localhost:1",
 			FlushInterval: 1 * time.Millisecond,
+			OnError:       func(e error) { logErr = e },
 		})
-		require.Error(t, err, "connection refused")
+		require.NoError(t, err)
+		require.Error(t, logErr, "connection refused")
 	})
 
 	t.Run("tesing http clients passed as options", func(t *testing.T) {


### PR DESCRIPTION
Description:
- we dont want to fail customer applications when remote config fails to fetch. In this pr, we set the initialized flag on the remote config struct to be true on successful config fetch. We only forward requests to supergood after successful initalization