### PR TITLE
[Bug]: Handle array in response/request string for sensitive keys

### DIFF
--- a/internal/redact/format.go
+++ b/internal/redact/format.go
@@ -12,20 +12,28 @@ import (
 // sensitive keys are of the form requestHeaders, responseBody etc. These values must
 // be mapped to fields in the parsed supergood event
 func formatSensitiveKey(keyPath string) ([]string, error) {
+	if len(keyPath) == 0 {
+		return []string{}, fmt.Errorf("invalid sensitive key value provided: %s", keyPath)
+	}
 	parts := strings.Split(keyPath, ".")
 	remainingParts := []string{}
+	first := parts[0]
 
-	switch parts[0] {
-	case shared.RequestHeadersStr:
+	if strings.Contains(first, shared.RequestHeadersStr) {
 		remainingParts = append(remainingParts, "Request", "Headers")
-	case shared.RequestBodyStr:
+	} else if strings.Contains(first, shared.RequestBodyStr) {
 		remainingParts = append(remainingParts, "Request", "Body")
-	case shared.ResponseHeadersStr:
+	} else if strings.Contains(first, shared.ResponseHeadersStr) {
 		remainingParts = append(remainingParts, "Response", "Headers")
-	case shared.ResponseBodyStr:
+	} else if strings.Contains(first, shared.ResponseBodyStr) {
 		remainingParts = append(remainingParts, "Response", "Body")
-	default:
+	} else {
 		return []string{}, fmt.Errorf("invalid sensitive key value provided: %s", keyPath)
+	}
+
+	// Check to make sure the first element was not an array (e.g. responseBody[])
+	if strings.Contains(first, "[]") {
+		remainingParts = append(remainingParts, "[]")
 	}
 
 	// Attempting to format indexed array elements (e.g. responseBody.nested.array[].field1)

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -126,7 +126,7 @@ func redactEventHelper(domain, url, originalPath string, pathParts []string, v r
 			return results, nil
 
 		default:
-			return nil, fmt.Errorf("redact.Redact: unsupported type %v for URL: %s, domain: %s,", v.Type().String(), url, domain)
+			return nil, fmt.Errorf("redact.Redact: unsupported type %v for URL: %s, domain: %s, path: %s", v.Type().String(), url, domain, originalPath)
 		}
 	}
 }


### PR DESCRIPTION
Description:
- sensitive key formatting can be formatted like responseBody[].id or requestBody[].key - these cases are missed in the current implementation.