### PR TITLE
[Internal]: Adding telemetry to client

### DIFF
--- a/options.go
+++ b/options.go
@@ -67,6 +67,10 @@ type Options struct {
 	// the remote config which is used to ignore / accept traffic from client endpoints
 	// as well as mask sensitive keys
 	RemoteConfigFetchInterval time.Duration
+
+	// ServiceName is an optional parameter that can be passed that helps differentiate
+	// services that use the same supergood api-key
+	ServiceName string
 }
 
 func (o *Options) parse() (*Options, error) {

--- a/supergood.go
+++ b/supergood.go
@@ -193,8 +193,11 @@ func (sg *Service) logError(e error) error {
 	})
 }
 
-func (sg *Service) logTelemtry(t telemetry) error {
-	return sg.post("/telemetry", t)
+func (sg *Service) logTelemtry(t telemetry) {
+	err := sg.post("/telemetry", t)
+	if err != nil {
+		sg.handleError(err)
+	}
 }
 
 func (sg *Service) post(path string, body any) error {

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -367,7 +367,7 @@ func Test_Supergood(t *testing.T) {
 		require.Error(t, logErr, "connection refused")
 	})
 
-	t.Run("tesing http clients passed as options", func(t *testing.T) {
+	t.Run("testing http clients passed as options", func(t *testing.T) {
 		mockBaseClient := &http.Client{}
 		mockServerChannel := make(chan int, 2)
 		options := &Options{
@@ -380,11 +380,11 @@ func Test_Supergood(t *testing.T) {
 			<-mockServerChannel
 			count++
 		}
-		// Three calls get tracked by the base client.
+		// Four calls get tracked by the base client.
 		// First to fetch the remote config
 		// One for the initial mock request
-		// and another tracking the call to the supergood backend
-		require.Equal(t, count, 3)
+		// and the last 2 are the telemetry call and event logging to the supergood backend
+		require.Equal(t, count, 4)
 		close(mockServerChannel)
 
 		require.Len(t, events, 1)

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -81,6 +81,11 @@ func mockApiServer(t *testing.T) string {
 			return
 		}
 
+		if r.URL.Path == "/telemetry" {
+			rw.Write([]byte(`{"message":"Success"}`))
+			return
+		}
+
 		if twiceBroken && (r.URL.Path != "/config") {
 			rw.WriteHeader(http.StatusInternalServerError)
 			rw.Write([]byte(`Oops`))
@@ -384,7 +389,7 @@ func Test_Supergood(t *testing.T) {
 		// First to fetch the remote config
 		// One for the initial mock request
 		// and the last 2 are the telemetry call and event logging to the supergood backend
-		require.Equal(t, count, 4)
+		require.Equal(t, 4, count)
 		close(mockServerChannel)
 
 		require.Len(t, events, 1)

--- a/types.go
+++ b/types.go
@@ -1,0 +1,44 @@
+package supergood
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/supergoodsystems/supergood-go/internal/event"
+	remoteconfig "github.com/supergoodsystems/supergood-go/internal/remote-config"
+)
+
+// Service collates request logs and uploads them to the Supergood API
+// in batches.
+//
+// As request logs are batched locally, you must call [Service.Close]
+// before your program exits to upload any pending logs.
+type Service struct {
+	// DefaultClient is a wrapped version of http.DefaultClient
+	// If you'd like to use supergood on all requests, set
+	// http.DefaultClient = sg.DefaultClient.
+
+	DefaultClient *http.Client
+
+	close   chan chan error
+	mutex   sync.Mutex
+	options *Options
+	queue   map[string]*event.Event
+	rc      remoteconfig.RemoteConfig
+}
+
+type errorReport struct {
+	Error   string         `json:"error"`
+	Message string         `json:"message"`
+	Payload packageVersion `json:"payload"`
+}
+
+type packageVersion struct {
+	Name    string `json:"packageName"`
+	Version string `json:"packageVersion"`
+}
+
+type telemetry struct {
+	CacheKeyCount int    `json:"cacheKeyCount"`
+	ServiceName   string `json:"serviceName"`
+}


### PR DESCRIPTION
Description:
- To prevent customer's experiencing any degradation wrt the supergood client, we will be emitting simple metrics starting with the number of events in the local cache to help us debug any potential issues.