### PR TITLE
Exposing log request / log response / remote config as public

### DIFF
--- a/roundtripper.go
+++ b/roundtripper.go
@@ -13,7 +13,7 @@ type roundTripper struct {
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	endpoint, errors := rt.sg.rc.MatchRequestAgainstEndpoints(req)
+	endpoint, errors := rt.sg.RemoteConfig.MatchRequestAgainstEndpoints(req)
 	for _, err := range errors {
 		rt.sg.handleError(err)
 	}
@@ -28,14 +28,14 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Do not forward to supergood if the request is not in the list of user provided
 	// selected requests OR if the request is ignored by the supergood remote config OR if
 	// remote config is not initialized
-	if !rt.sg.options.SelectRequests(req) || endpointAction == "Ignore" || !rt.sg.rc.IsInitialized() {
+	if !rt.sg.options.SelectRequests(req) || endpointAction == "Ignore" || !rt.sg.RemoteConfig.IsInitialized() {
 		return rt.next.RoundTrip(req)
 	}
 
 	id := uuid.NewV4().String()
-	rt.sg.logRequest(id, event.NewRequest(id, req), endpointId)
+	rt.sg.LogRequest(id, event.NewRequest(id, req), endpointId)
 	resp, err := rt.next.RoundTrip(req)
-	rt.sg.logResponse(id, event.NewResponse(resp, err))
+	rt.sg.LogResponse(id, event.NewResponse(resp, err))
 
 	return resp, err
 }

--- a/types.go
+++ b/types.go
@@ -20,11 +20,11 @@ type Service struct {
 
 	DefaultClient *http.Client
 
-	close   chan chan error
-	mutex   sync.Mutex
-	options *Options
-	queue   map[string]*event.Event
-	rc      remoteconfig.RemoteConfig
+	close        chan chan error
+	mutex        sync.Mutex
+	options      *Options
+	queue        map[string]*event.Event
+	RemoteConfig remoteconfig.RemoteConfig
 }
 
 type errorReport struct {


### PR DESCRIPTION
Description:
- for the ebpf agent, I'll want to re-use log request / responses and filtering abilities. 