### PR TITLE
[Feature]: Expose selected requests

### DIFF
--- a/supergood.go
+++ b/supergood.go
@@ -113,6 +113,10 @@ func (sg *Service) LogResponse(id string, resp *event.Response) {
 	}
 }
 
+func (sg *Service) GetSelectedRequests(req *http.Request) bool {
+	return sg.options.SelectRequests(req)
+}
+
 func (sg *Service) loop() {
 	var closed chan error
 	for {


### PR DESCRIPTION
Description:
- optional parameter SelectRequests is used by the supergood-go client to explicitly mark certain hosts to be ignored. https://github.com/supergoodsystems/supergood-go/blob/master/options.go#L49

- Making getter function publicly accessible for use in ebpf agent.