### PR TITLE
[Bug]: Fix incomplete redact functionality

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
+        with:
+          go-version: '1.19.13' 
       - run: go test ./... -v -count=1 -shuffle=on
       - run: gofmt -s -w . && git diff --exit-code
       - run: go mod tidy && git diff --exit-code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supergoodsystems/supergood-go
 
-go 1.20
+go 1.19
 
 require (
 	github.com/satori/go.uuid v1.2.0

--- a/pkg/event/utils.go
+++ b/pkg/event/utils.go
@@ -79,7 +79,7 @@ func duplicateBody(r io.ReadCloser) (body any, rc io.ReadCloser) {
 	rc = &readCloser{c: r, r: bytes.NewReader(b), e: err}
 
 	if !utf8.Valid(b) {
-		body = b
+		body = &b
 	} else {
 		body = map[string]any{}
 		if err := json.Unmarshal(b, &body); err != nil {

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -17,10 +17,7 @@ func Redact(events []*event.Event, rc *remoteconfig.RemoteConfig) []error {
 		domain := domainutils.GetDomainFromHost(e.Request.URL)
 		if forceRedact {
 			meta, redactErrs := redactAll(domain, e.Request.URL, e)
-			if len(redactErrs) != 0 {
-				errs = append(errs, redactErrs...)
-				continue
-			}
+			errs = append(errs, redactErrs...)
 			e.MetaData.SensitiveKeys = append(e.MetaData.SensitiveKeys, meta...)
 			continue
 		}

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -16,9 +16,9 @@ func Redact(events []*event.Event, rc *remoteconfig.RemoteConfig) []error {
 	for _, e := range events {
 		domain := domainutils.GetDomainFromHost(e.Request.URL)
 		if forceRedact {
-			meta, err := redactAll(domain, e.Request.URL, e)
-			if err != nil {
-				errs = append(errs, err)
+			meta, redactErrs := redactAll(domain, e.Request.URL, e)
+			if len(redactErrs) != 0 {
+				errs = append(errs, redactErrs...)
 				continue
 			}
 			e.MetaData.SensitiveKeys = append(e.MetaData.SensitiveKeys, meta...)

--- a/pkg/redact/redact_all.go
+++ b/pkg/redact/redact_all.go
@@ -206,11 +206,15 @@ func shouldTraverse(v reflect.Value) bool {
 
 func prepareOutput(v reflect.Value, path string) []event.RedactedKeyMeta {
 	size := getSize(v)
+	val := v
+	if v.Type().Kind() == reflect.Interface || v.Type().Kind() == reflect.Pointer {
+		val = v.Elem()
+	}
 	return []event.RedactedKeyMeta{
 		{
 			KeyPath: path,
 			Length:  size,
-			Type:    formatKind(v.Type().Kind()),
+			Type:    formatKind(val.Type().Kind()),
 		},
 	}
 }

--- a/pkg/redact/redact_all.go
+++ b/pkg/redact/redact_all.go
@@ -42,12 +42,16 @@ func redactAll(domain, url string, e *event.Event) ([]event.RedactedKeyMeta, []e
 	return meta, errs
 }
 
+// NOTE: duplicate body will attempt to cast to map[string]interface{} in the case it cannot
+// it will cast the response into a string. In the case the body is returned as a string, the
+// reflected value is not settable - and is why this check is in place below
 func redactAllResponseBody(response *event.Response, path string) ([]event.RedactedKeyMeta, []error) {
 	errs := []error{}
 	result := []event.RedactedKeyMeta{}
 	if response.Body == nil {
 		return result, errs
 	}
+
 	v := reflect.ValueOf(response.Body)
 	if !v.IsValid() {
 		errs = append(errs, fmt.Errorf("redact-all: invalid reflected value at path: %s", path))
@@ -61,6 +65,9 @@ func redactAllResponseBody(response *event.Response, path string) ([]event.Redac
 	return redactAllHelperRecurse(v, path)
 }
 
+// NOTE: duplicate body will attempt to cast to map[string]interface{} in the case it cannot
+// it will cast the request into a string. In the case the body is returned as a string, the
+// reflected value is not settable - and is why this check is in place below
 func redactAllRequestBody(request *event.Request, path string) ([]event.RedactedKeyMeta, []error) {
 	errs := []error{}
 	result := []event.RedactedKeyMeta{}

--- a/pkg/redact/redact_all_test.go
+++ b/pkg/redact/redact_all_test.go
@@ -29,7 +29,7 @@ func Test_Redact_All(t *testing.T) {
 		require.Equal(t, nil, events[0].Response.Body.(map[string]any)["keyInt"])
 		require.Equal(t, nil, events[0].Response.Body.(map[string]any)["keyFloat"])
 		require.Equal(t, nil, events[0].Response.Body.(map[string]any)["nested"].(map[string]any)["key"])
-		require.Equal(t, nil, events[0].Request.Headers["key"])
+		require.Equal(t, "", events[0].Request.Headers["key"])
 
 		// ensure all keys tracked are redacted
 		expectedKeys := []SensitiveKeyExpected{

--- a/pkg/redact/redact_all_test.go
+++ b/pkg/redact/redact_all_test.go
@@ -19,17 +19,17 @@ func Test_Redact_All(t *testing.T) {
 		errors := Redact(events, config)
 
 		require.Len(t, errors, 0)
-		require.Equal(t, "", events[0].Request.Body.(map[string]any)["key"])
-		require.Equal(t, 0, events[0].Request.Body.(map[string]any)["keyInt"])
-		require.Equal(t, float64(0), events[0].Request.Body.(map[string]any)["keyFloat"])
-		require.Equal(t, "", events[0].Request.Body.(map[string]any)["nested"].(map[string]any)["key"])
-		require.Equal(t, []string(nil), events[0].Request.Body.(map[string]any)["array"])
-		require.Equal(t, "", events[0].Request.Body.(map[string]any)["arrayOfObj"].([]map[string]any)[0]["field1"])
-		require.Equal(t, "", events[0].Response.Body.(map[string]any)["key"])
-		require.Equal(t, 0, events[0].Response.Body.(map[string]any)["keyInt"])
-		require.Equal(t, float64(0), events[0].Response.Body.(map[string]any)["keyFloat"])
-		require.Equal(t, "", events[0].Response.Body.(map[string]any)["nested"].(map[string]any)["key"])
-		require.Equal(t, "", events[0].Request.Headers["key"])
+		require.Equal(t, nil, events[0].Request.Body.(map[string]any)["key"])
+		require.Equal(t, nil, events[0].Request.Body.(map[string]any)["keyInt"])
+		require.Equal(t, nil, events[0].Request.Body.(map[string]any)["keyFloat"])
+		require.Equal(t, nil, events[0].Request.Body.(map[string]any)["nested"].(map[string]any)["key"])
+		require.Equal(t, nil, events[0].Request.Body.(map[string]any)["array"])
+		require.Equal(t, nil, events[0].Request.Body.(map[string]any)["arrayOfObj"].([]map[string]any)[0]["field1"])
+		require.Equal(t, nil, events[0].Response.Body.(map[string]any)["key"])
+		require.Equal(t, nil, events[0].Response.Body.(map[string]any)["keyInt"])
+		require.Equal(t, nil, events[0].Response.Body.(map[string]any)["keyFloat"])
+		require.Equal(t, nil, events[0].Response.Body.(map[string]any)["nested"].(map[string]any)["key"])
+		require.Equal(t, nil, events[0].Request.Headers["key"])
 
 		// ensure all keys tracked are redacted
 		expectedKeys := []SensitiveKeyExpected{

--- a/pkg/redact/size.go
+++ b/pkg/redact/size.go
@@ -5,6 +5,9 @@ import "reflect"
 // Note: this is a naive way of generating the size of a reflected object
 func getSize(v reflect.Value) int {
 	size := 0
+	if !v.IsValid() {
+		return size
+	}
 	switch v.Kind() {
 	case reflect.Interface, reflect.Pointer:
 		size += getSize(v.Elem())
@@ -24,7 +27,9 @@ func getSize(v reflect.Value) int {
 			size += getSize(v.Field(i))
 		}
 	default:
-		size += int(v.Type().Size())
+		if !v.IsZero() || v.Type() != nil {
+			size += int(v.Type().Size())
+		}
 	}
 	return size
 }

--- a/supergood.go
+++ b/supergood.go
@@ -158,7 +158,9 @@ func (sg *Service) flush(force bool) error {
 
 	errs := redact.Redact(toSend, &sg.RemoteConfig)
 	for _, err := range errs {
-		sg.handleError(err)
+		if err2 := sg.logError(err); err2 != nil {
+			sg.options.OnError(err2)
+		}
 	}
 
 	sg.logTelemtry(telemetry{


### PR DESCRIPTION
Description:
- passing invalid unicode byte stream reference -> allows bytes to be redacted by redact_all func
- aggregating errors and redactions instead of failing fast
- hardening checks for nil values and for non settable reflected values 