### PR TITLE
[Bug]: Checking whether reflected value is zero value in prepareOutput

### DIFF
--- a/pkg/redact/redact_all.go
+++ b/pkg/redact/redact_all.go
@@ -207,14 +207,18 @@ func shouldTraverse(v reflect.Value) bool {
 func prepareOutput(v reflect.Value, path string) []event.RedactedKeyMeta {
 	size := getSize(v)
 	val := v
-	if v.Type().Kind() == reflect.Interface || v.Type().Kind() == reflect.Pointer {
+	if val.IsValid() && (val.Type().Kind() == reflect.Interface || val.Type().Kind() == reflect.Pointer) {
 		val = v.Elem()
+	}
+	kind := "invalid"
+	if val.IsValid() {
+		kind = formatKind(val.Type().Kind())
 	}
 	return []event.RedactedKeyMeta{
 		{
 			KeyPath: path,
 			Length:  size,
-			Type:    formatKind(val.Type().Kind()),
+			Type:    kind,
 		},
 	}
 }


### PR DESCRIPTION
Description:
 - in the previous PR, prepareOutput was extended to check wether the passed reflected value was a pointer or interface, and then to take the Elem() of that value to determine the fields primitive type. That extension failed to include a check for whether the derived value was the zero value. 