### PR TITLE
[Improvements]: Updating roundtripper passthrough logic

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -25,7 +25,7 @@ func TestOptions_defaults(t *testing.T) {
 	require.Equal(t, len(o.RedactResponseBodyKeys), 0)
 	require.Equal(t, len(o.AllowedDomains), 0)
 	require.Equal(t, len(o.RedactRequestHeaderKeys), 0)
-	require.True(t, o.SelectRequests(nil))
+	require.Nil(t, o.SelectRequests)
 	require.NotNil(t, o.OnError)
 	require.Equal(t, o.FlushInterval, 1*time.Second)
 	require.Equal(t, o.HTTPClient, http.DefaultClient)

--- a/pkg/redact/redact_all.go
+++ b/pkg/redact/redact_all.go
@@ -207,14 +207,18 @@ func shouldTraverse(v reflect.Value) bool {
 func prepareOutput(v reflect.Value, path string) []event.RedactedKeyMeta {
 	size := getSize(v)
 	val := v
-	if v.Type().Kind() == reflect.Interface || v.Type().Kind() == reflect.Pointer {
+	if val.IsValid() && (val.Type().Kind() == reflect.Interface || val.Type().Kind() == reflect.Pointer) {
 		val = v.Elem()
+	}
+	kind := "invalid"
+	if val.IsValid() {
+		kind = formatKind(val.Type().Kind())
 	}
 	return []event.RedactedKeyMeta{
 		{
 			KeyPath: path,
 			Length:  size,
-			Type:    formatKind(val.Type().Kind()),
+			Type:    kind,
 		},
 	}
 }

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -25,9 +25,6 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		endpointAction = endpoint.Action
 	}
 
-	// Do not forward to supergood if the request is not in the list of user provided
-	// selected requests OR if the request is ignored by the supergood remote config OR if
-	// remote config is not initialized
 	if !rt.shouldLogRequest(req, endpointAction) {
 		return rt.next.RoundTrip(req)
 	}

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -28,7 +28,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Do not forward to supergood if the request is not in the list of user provided
 	// selected requests OR if the request is ignored by the supergood remote config OR if
 	// remote config is not initialized
-	if !rt.sg.options.SelectRequests(req) || endpointAction == "Ignore" || !rt.sg.RemoteConfig.IsInitialized() {
+	if !rt.shouldLogRequest(req, endpointAction) {
 		return rt.next.RoundTrip(req)
 	}
 
@@ -51,4 +51,21 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	return resp, err
+}
+
+func (rt *roundTripper) shouldLogRequest(req *http.Request, endpointAction string) bool {
+	isSelectedRequest := true
+	if rt.sg.options.SelectRequests != nil {
+		isSelectedRequest = rt.sg.options.SelectRequests(req)
+	}
+
+	allowed, err := rt.sg.options.isRequestInAllowedDomains(req)
+	if err != nil {
+		rt.sg.handleError(err)
+	}
+
+	if endpointAction == "Ignore" || !rt.sg.RemoteConfig.IsInitialized() || !isSelectedRequest || !allowed {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Description:
- currently, options.AllowedDomains and options.SelectRequests cannot be both set. 
- in this PR, we treat these as independent checks