### PR TITLE
[Feature]: Support for categorizing endpoints to include method

### DIFF
--- a/pkg/redact/redact_all.go
+++ b/pkg/redact/redact_all.go
@@ -207,14 +207,18 @@ func shouldTraverse(v reflect.Value) bool {
 func prepareOutput(v reflect.Value, path string) []event.RedactedKeyMeta {
 	size := getSize(v)
 	val := v
-	if v.Type().Kind() == reflect.Interface || v.Type().Kind() == reflect.Pointer {
+	if val.IsValid() && (val.Type().Kind() == reflect.Interface || val.Type().Kind() == reflect.Pointer) {
 		val = v.Elem()
+	}
+	kind := "invalid"
+	if val.IsValid() {
+		kind = formatKind(val.Type().Kind())
 	}
 	return []event.RedactedKeyMeta{
 		{
 			KeyPath: path,
 			Length:  size,
-			Type:    formatKind(val.Type().Kind()),
+			Type:    kind,
 		},
 	}
 }

--- a/pkg/remote-config/cache.go
+++ b/pkg/remote-config/cache.go
@@ -50,6 +50,7 @@ func (rc *RemoteConfig) Create(remoteConfigArray []RemoteConfigResponse) error {
 			}
 			endpointCacheVal := EndpointCacheVal{
 				Id:            endpoint.Id,
+				Method:        endpoint.Method,
 				Regex:         *regex,
 				Location:      endpoint.MatchingRegex.Location,
 				Action:        endpoint.EndpointConfiguration.Action,

--- a/pkg/remote-config/match.go
+++ b/pkg/remote-config/match.go
@@ -23,7 +23,7 @@ func (rc *RemoteConfig) MatchRequestAgainstEndpoints(req *http.Request) (*Endpoi
 		return nil, errs
 	}
 	for _, endpoint := range endpoints {
-		if req.Method != endpoint.Method {
+		if strings.EqualFold(req.Method, endpoint.Method) || (req.Method == "" && endpoint.Method != "GET") {
 			continue
 		}
 		testVal, err := stringifyRequestAtLocation(req, endpoint.Location)

--- a/pkg/remote-config/match.go
+++ b/pkg/remote-config/match.go
@@ -23,6 +23,9 @@ func (rc *RemoteConfig) MatchRequestAgainstEndpoints(req *http.Request) (*Endpoi
 		return nil, errs
 	}
 	for _, endpoint := range endpoints {
+		if req.Method != endpoint.Method {
+			continue
+		}
 		testVal, err := stringifyRequestAtLocation(req, endpoint.Location)
 		if err != nil {
 			errs = append(errs, err)

--- a/pkg/remote-config/match.go
+++ b/pkg/remote-config/match.go
@@ -23,7 +23,7 @@ func (rc *RemoteConfig) MatchRequestAgainstEndpoints(req *http.Request) (*Endpoi
 		return nil, errs
 	}
 	for _, endpoint := range endpoints {
-		if strings.EqualFold(req.Method, endpoint.Method) || (req.Method == "" && endpoint.Method != "GET") {
+		if !strings.EqualFold(req.Method, endpoint.Method) || (req.Method == "" && endpoint.Method != "GET") {
 			continue
 		}
 		testVal, err := stringifyRequestAtLocation(req, endpoint.Location)

--- a/pkg/remote-config/types.go
+++ b/pkg/remote-config/types.go
@@ -47,6 +47,7 @@ type RemoteConfigResponse struct {
 type Endpoint struct {
 	Id                    string                `json:"id"`
 	Name                  string                `json:"name"`
+	Method                string                `json:"method"`
 	MatchingRegex         MatchingRegex         `json:"matchingRegex"`
 	EndpointConfiguration EndpointConfiguration `json:"endpointConfiguration"`
 }
@@ -74,6 +75,7 @@ type SensitiveKeys struct {
 type EndpointCacheVal struct {
 	Id            string
 	Regex         regexp.Regexp
+	Method        string
 	Location      string
 	Action        string
 	SensitiveKeys []SensitiveKeys

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -111,8 +111,8 @@ func mockApiServer(t *testing.T) string {
 					Name:   "Ignore me domain",
 					Endpoints: []remoteconfig.Endpoint{
 						{
-							Id:   "test-endpoint-id",
-							Name: "ignore me endpoint",
+							Id:     "test-endpoint-id",
+							Name:   "ignore me endpoint",
 							Method: "GET",
 							MatchingRegex: remoteconfig.MatchingRegex{
 								Location: "path",
@@ -130,8 +130,8 @@ func mockApiServer(t *testing.T) string {
 					Name:   "Blocked domain",
 					Endpoints: []remoteconfig.Endpoint{
 						{
-							Id:   "test-endpoint-id",
-							Name: "block me endpoint",
+							Id:     "test-endpoint-id",
+							Name:   "block me endpoint",
 							Method: "GET",
 							MatchingRegex: remoteconfig.MatchingRegex{
 								Location: "path",

--- a/supergood_test.go
+++ b/supergood_test.go
@@ -113,6 +113,7 @@ func mockApiServer(t *testing.T) string {
 						{
 							Id:   "test-endpoint-id",
 							Name: "ignore me endpoint",
+							Method: "GET",
 							MatchingRegex: remoteconfig.MatchingRegex{
 								Location: "path",
 								Regex:    "/ignore-me",
@@ -131,6 +132,7 @@ func mockApiServer(t *testing.T) string {
 						{
 							Id:   "test-endpoint-id",
 							Name: "block me endpoint",
+							Method: "GET",
 							MatchingRegex: remoteconfig.MatchingRegex{
 								Location: "path",
 								Regex:    "/block-me",


### PR DESCRIPTION
Description:
- Today, the sdk will only match an event based off a regex provided in the remote config. However, multiple api's can match the same regex and have different methods. Since we know method will always be something we want to categorize against, we will explicitly do so (instead of having an array of regex matchers)